### PR TITLE
eta-expand versioned_type deriver; no-op aliases

### DIFF
--- a/src/dummy_derivers.ml
+++ b/src/dummy_derivers.ml
@@ -1,0 +1,26 @@
+(* dummy_derivers.ml -- no-op derivers for aliasing *)
+
+open Core_kernel
+
+let str_type_decl =
+  let deriver ~loc:_ ~path:_ (_rec_flag, _type_decls) = [] in
+  Ppxlib.Deriving.Generator.make_noarg deriver
+
+let str_type_ext =
+  let deriver ~loc:_ ~path:_ _type_ext = [] in
+  Ppxlib.Deriving.Generator.make_noarg deriver
+
+let type_decl_dummy_deriver =
+  Ppxlib.Deriving.add "dummy_type_decl" ~str_type_decl
+
+let type_ext_dummy_deriver = Ppxlib.Deriving.add "dummy_type_ext" ~str_type_ext
+
+let add_type_decl_aliases aliases =
+  List.iter aliases ~f:(fun alias ->
+      Ppxlib.Deriving.add_alias alias [type_decl_dummy_deriver]
+      |> Ppxlib.Deriving.ignore )
+
+let add_type_ext_aliases aliases =
+  List.iter aliases ~f:(fun alias ->
+      Ppxlib.Deriving.add_alias alias [type_ext_dummy_deriver]
+      |> Ppxlib.Deriving.ignore )

--- a/src/dune
+++ b/src/dune
@@ -22,7 +22,7 @@
             ppx_deriving_yojson)
  (preprocess (pps ppxlib.metaquot)))
 
- (executable
+(executable
  (name print_binable_functors)
  (modules print_binable_functors)
  (libraries ppx_version

--- a/src/print_binable_functors.ml
+++ b/src/print_binable_functors.ml
@@ -96,4 +96,5 @@ let preprocess_impl str =
 
 let () =
   Ppxlib.Driver.register_transformation name ~preprocess_impl ;
+  Ppx_version.Dummy_derivers.add_type_ext_aliases ["register_event"] ;
   Ppxlib.Driver.standalone ()

--- a/src/print_versioned_types.ml
+++ b/src/print_versioned_types.ml
@@ -2,4 +2,5 @@
 
 let () =
   Ppx_version.Versioned_type.set_printing () ;
+  Ppx_version.Dummy_derivers.add_type_ext_aliases ["register_event"] ;
   Ppxlib.Driver.standalone ()

--- a/src/versioned_type.ml
+++ b/src/versioned_type.ml
@@ -544,17 +544,19 @@ let str_type_decl :
     let open Ppxlib.Deriving.Args in
     empty +> flag "rpc" +> flag "asserted" +> flag "binable"
   in
-  let deriver =
-    choose_deriver ~printing:Printing.print_type
-      ~deriving:Deriving.generate_let_bindings_for_type_decl_str
+  let deriver ~loc ~path (rec_flag, type_decls) rpc asserted binable =
+    (choose_deriver ~printing:Printing.print_type
+       ~deriving:Deriving.generate_let_bindings_for_type_decl_str)
+      ~loc ~path (rec_flag, type_decls) rpc asserted binable
   in
   Ppxlib.Deriving.Generator.make args deriver
 
 let sig_type_decl :
     (signature, rec_flag * type_declaration list) Ppxlib.Deriving.Generator.t =
-  let deriver =
-    choose_deriver ~printing:Printing.gen_empty_sig
-      ~deriving:Deriving.generate_val_decls_for_type_decl_sig
+  let deriver ~loc ~path (rec_flag, type_decls) =
+    (choose_deriver ~printing:Printing.gen_empty_sig
+       ~deriving:Deriving.generate_val_decls_for_type_decl_sig)
+      ~loc ~path (rec_flag, type_decls)
   in
   Ppxlib.Deriving.Generator.make_noarg deriver
 


### PR DESCRIPTION
Use eta-expansion to make the choice of printing/nonprinting version derivers at preprocessing time.

Create dummy, no-op derivers for type declarations and extensions, and a mechanism to alias them. That allows the version and binable functor printers to mention derivers like `register_event` from Coda, without introducing a dependency on Coda.
