### PR TITLE
Dummy derivers may take arguments

### DIFF
--- a/src/dummy_derivers.ml
+++ b/src/dummy_derivers.ml
@@ -1,26 +1,37 @@
-(* dummy_derivers.ml -- no-op derivers for aliasing *)
+(* dummy_derivers.ml -- create no-op derivers *)
 
 open Core_kernel
 
-let str_type_decl =
-  let deriver ~loc:_ ~path:_ (_rec_flag, _type_decls) = [] in
-  Ppxlib.Deriving.Generator.make_noarg deriver
+(* type declarations *)
+let type_decl_gen0 ~loc:_ ~path:_ _(_rec_flag,_type_decls) = []
+let type_decl_gen1 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ = []
+let type_decl_gen2 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ _ = []
+let type_decl_gen3 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ _ _ = []
+let type_decl_gen4 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ _ _ _ = []
 
-let str_type_ext =
-  let deriver ~loc:_ ~path:_ _type_ext = [] in
-  Ppxlib.Deriving.Generator.make_noarg deriver
+let add_type_decl_no_op name args generator =
+  let str_type_decl = Ppxlib.Deriving.Generator.make args generator in
+  Ppxlib.Deriving.add name ~str_type_decl |> Ppxlib.Deriving.ignore
 
-let type_decl_dummy_deriver =
-  Ppxlib.Deriving.add "dummy_type_decl" ~str_type_decl
+let add_type_decl_no_op0 name args = add_type_decl_no_op name args type_decl_gen0
+let add_type_decl_no_op1 name args = add_type_decl_no_op name args type_decl_gen1
+let add_type_decl_no_op2 name args = add_type_decl_no_op name args type_decl_gen2
+let add_type_decl_no_op3 name args = add_type_decl_no_op name args type_decl_gen3
+let add_type_decl_no_op4 name args = add_type_decl_no_op name args type_decl_gen4
 
-let type_ext_dummy_deriver = Ppxlib.Deriving.add "dummy_type_ext" ~str_type_ext
+(* type extensions *)
+let type_ext_gen0 ~loc:_ ~path:_ _type_ext = []
+let type_ext_gen1 ~loc:_ ~path:_ _type_ext _ = []
+let type_ext_gen2 ~loc:_ ~path:_ _type_ext _ _ = []
+let type_ext_gen3 ~loc:_ ~path:_ _type_ext _ _ _ = []
+let type_ext_gen4 ~loc:_ ~path:_ _type_ext _ _ _ _ = []
 
-let add_type_decl_aliases aliases =
-  List.iter aliases ~f:(fun alias ->
-      Ppxlib.Deriving.add_alias alias [type_decl_dummy_deriver]
-      |> Ppxlib.Deriving.ignore )
+let add_type_ext_no_op name args generator =
+  let str_type_ext = Ppxlib.Deriving.Generator.make args generator in
+  Ppxlib.Deriving.add name ~str_type_ext |> Ppxlib.Deriving.ignore
 
-let add_type_ext_aliases aliases =
-  List.iter aliases ~f:(fun alias ->
-      Ppxlib.Deriving.add_alias alias [type_ext_dummy_deriver]
-      |> Ppxlib.Deriving.ignore )
+let add_type_ext_no_op0 name args = add_type_ext_no_op name args type_ext_gen0
+let add_type_ext_no_op1 name args = add_type_ext_no_op name args type_ext_gen1
+let add_type_ext_no_op2 name args = add_type_ext_no_op name args type_ext_gen2
+let add_type_ext_no_op3 name args = add_type_ext_no_op name args type_ext_gen3
+let add_type_ext_no_op4 name args = add_type_ext_no_op name args type_ext_gen4

--- a/src/dummy_derivers.ml
+++ b/src/dummy_derivers.ml
@@ -1,7 +1,5 @@
 (* dummy_derivers.ml -- create no-op derivers *)
 
-open Core_kernel
-
 (* type declarations *)
 let type_decl_gen0 ~loc:_ ~path:_ _(_rec_flag,_type_decls) = []
 let type_decl_gen1 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ = []

--- a/src/dummy_derivers.ml
+++ b/src/dummy_derivers.ml
@@ -1,11 +1,11 @@
 (* dummy_derivers.ml -- create no-op derivers *)
 
 (* type declarations *)
-let type_decl_gen0 ~loc:_ ~path:_ _(_rec_flag,_type_decls) = []
-let type_decl_gen1 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ = []
-let type_decl_gen2 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ _ = []
-let type_decl_gen3 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ _ _ = []
-let type_decl_gen4 ~loc:_ ~path:_ _(_rec_flag,_type_decls) _ _ _ _ = []
+let type_decl_gen0 ~loc:_ ~path:_ (_rec_flag,_type_decls) = []
+let type_decl_gen1 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ = []
+let type_decl_gen2 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ _ = []
+let type_decl_gen3 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ _ _ = []
+let type_decl_gen4 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ _ _ _ = []
 
 let add_type_decl_no_op name args generator =
   let str_type_decl = Ppxlib.Deriving.Generator.make args generator in

--- a/src/print_binable_functors.ml
+++ b/src/print_binable_functors.ml
@@ -96,5 +96,9 @@ let preprocess_impl str =
 
 let () =
   Ppxlib.Driver.register_transformation name ~preprocess_impl ;
-  Ppx_version.Dummy_derivers.add_type_ext_aliases ["register_event"] ;
+  let register_event_args =
+    let open Ppxlib.Deriving.Args in
+    empty +> arg "msg" __
+  in
+  Ppx_version.Dummy_derivers.add_type_ext_no_op1 "register_event" register_event_args;
   Ppxlib.Driver.standalone ()

--- a/src/print_versioned_types.ml
+++ b/src/print_versioned_types.ml
@@ -2,5 +2,9 @@
 
 let () =
   Ppx_version.Versioned_type.set_printing () ;
-  Ppx_version.Dummy_derivers.add_type_ext_aliases ["register_event"] ;
+  let register_event_args =
+    let open Ppxlib.Deriving.Args in
+    empty +> arg "msg" __
+  in
+  Ppx_version.Dummy_derivers.add_type_ext_no_op1 "register_event" register_event_args;
   Ppxlib.Driver.standalone ()


### PR DESCRIPTION
The dummy derivers for aliasing did not allow the aliases to take arguments.
That's a problem for `register_event`, which can take a `msg` argument.

Instead, for each no-op deriver we wish to run, we specify the arguments as a `Ppxlib.Deriving.Args.t` value, and use a generator of the appropriate arity. The code allows between 0 and 4 arguments, although that can easily be extended.

Tested a type extension with `deriving register_event`, with and without the `msg` argument. Tested with that argument given as a string constant, and also as a more complex string-valued expression.

