### PR TITLE
Add .gitignore, dummy cleanup

### DIFF
--- a/src/dummy_derivers.ml
+++ b/src/dummy_derivers.ml
@@ -1,5 +1,7 @@
 (* dummy_derivers.ml -- create no-op derivers *)
 
+open Ppxlib.Deriving
+
 (* type declarations *)
 let type_decl_gen0 ~loc:_ ~path:_ (_rec_flag,_type_decls) = []
 let type_decl_gen1 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ = []
@@ -7,15 +9,15 @@ let type_decl_gen2 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ _ = []
 let type_decl_gen3 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ _ _ = []
 let type_decl_gen4 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ _ _ _ = []
 
-let add_type_decl_no_op name args generator =
-  let str_type_decl = Ppxlib.Deriving.Generator.make args generator in
-  Ppxlib.Deriving.add name ~str_type_decl |> Ppxlib.Deriving.ignore
+let make_type_decl_no_op name args generator =
+  let str_type_decl = Generator.make args generator in
+  add name ~str_type_decl |> ignore
 
-let add_type_decl_no_op0 name args = add_type_decl_no_op name args type_decl_gen0
-let add_type_decl_no_op1 name args = add_type_decl_no_op name args type_decl_gen1
-let add_type_decl_no_op2 name args = add_type_decl_no_op name args type_decl_gen2
-let add_type_decl_no_op3 name args = add_type_decl_no_op name args type_decl_gen3
-let add_type_decl_no_op4 name args = add_type_decl_no_op name args type_decl_gen4
+let add_type_decl name = make_type_decl_no_op name Args.empty type_decl_gen0
+let add_type_decl1 name args = make_type_decl_no_op name args type_decl_gen1
+let add_type_decl2 name args = make_type_decl_no_op name args type_decl_gen2
+let add_type_decl3 name args = make_type_decl_no_op name args type_decl_gen3
+let add_type_decl4 name args = make_type_decl_no_op name args type_decl_gen4
 
 (* type extensions *)
 let type_ext_gen0 ~loc:_ ~path:_ _type_ext = []
@@ -24,12 +26,12 @@ let type_ext_gen2 ~loc:_ ~path:_ _type_ext _ _ = []
 let type_ext_gen3 ~loc:_ ~path:_ _type_ext _ _ _ = []
 let type_ext_gen4 ~loc:_ ~path:_ _type_ext _ _ _ _ = []
 
-let add_type_ext_no_op name args generator =
-  let str_type_ext = Ppxlib.Deriving.Generator.make args generator in
-  Ppxlib.Deriving.add name ~str_type_ext |> Ppxlib.Deriving.ignore
+let make_type_ext_no_op name args generator =
+  let str_type_ext = Generator.make args generator in
+  add name ~str_type_ext |> ignore
 
-let add_type_ext_no_op0 name args = add_type_ext_no_op name args type_ext_gen0
-let add_type_ext_no_op1 name args = add_type_ext_no_op name args type_ext_gen1
-let add_type_ext_no_op2 name args = add_type_ext_no_op name args type_ext_gen2
-let add_type_ext_no_op3 name args = add_type_ext_no_op name args type_ext_gen3
-let add_type_ext_no_op4 name args = add_type_ext_no_op name args type_ext_gen4
+let add_type_ext name = make_type_ext_no_op name Args.empty type_ext_gen0
+let add_type_ext1 name args = make_type_ext_no_op name args type_ext_gen1
+let add_type_ext2 name args = make_type_ext_no_op name args type_ext_gen2
+let add_type_ext3 name args = make_type_ext_no_op name args type_ext_gen3
+let add_type_ext4 name args = make_type_ext_no_op name args type_ext_gen4

--- a/src/print_binable_functors.ml
+++ b/src/print_binable_functors.ml
@@ -100,5 +100,5 @@ let () =
     let open Ppxlib.Deriving.Args in
     empty +> arg "msg" __
   in
-  Ppx_version.Dummy_derivers.add_type_ext_no_op1 "register_event" register_event_args;
+  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_args;
   Ppxlib.Driver.standalone ()

--- a/src/print_versioned_types.ml
+++ b/src/print_versioned_types.ml
@@ -6,5 +6,5 @@ let () =
     let open Ppxlib.Deriving.Args in
     empty +> arg "msg" __
   in
-  Ppx_version.Dummy_derivers.add_type_ext_no_op1 "register_event" register_event_args;
+  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_args;
   Ppxlib.Driver.standalone ()


### PR DESCRIPTION
Without a `.gitignore`, in `coda`, `git status` always showed the `.merlin` file after a build.

Shorted the names to build dummy derivers. Use `Args.empty` when 0 arguments, don't have to pass it.