### PR TITLE
Fix merlin in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 _build
-*.merlin
+**/.merlin


### PR DESCRIPTION
There is a `.merlin` file in `src/` which was not being ignored, which caused git to think the repo was dirty, which caused `git submodule update --init` to fail in coda :)