### PR TITLE
Dhall_type dummy deriver

### DIFF
--- a/src/dummy_derivers.ml
+++ b/src/dummy_derivers.ml
@@ -2,6 +2,12 @@
 
 open Ppxlib.Deriving
 
+(* arguments *)
+let make_args1 a1 = Args.(empty +> a1)
+let make_args2 a1 a2 = Args.(make_args1 a1 +> a2)
+let make_args3 a1 a2 a3 = Args.(make_args2 a1 a2 +> a3)
+let make_args4 a1 a2 a3 a4 = Args.(make_args3 a1 a2 a3 +> a4)
+
 (* type declarations *)
 let type_decl_gen0 ~loc:_ ~path:_ (_rec_flag,_type_decls) = []
 let type_decl_gen1 ~loc:_ ~path:_ (_rec_flag,_type_decls) _ = []
@@ -14,10 +20,10 @@ let make_type_decl_no_op name args generator =
   add name ~str_type_decl |> ignore
 
 let add_type_decl name = make_type_decl_no_op name Args.empty type_decl_gen0
-let add_type_decl1 name args = make_type_decl_no_op name args type_decl_gen1
-let add_type_decl2 name args = make_type_decl_no_op name args type_decl_gen2
-let add_type_decl3 name args = make_type_decl_no_op name args type_decl_gen3
-let add_type_decl4 name args = make_type_decl_no_op name args type_decl_gen4
+let add_type_decl1 name a1 = make_type_decl_no_op name (make_args1 a1) type_decl_gen1
+let add_type_decl2 name a1 a2 = make_type_decl_no_op name (make_args2 a1 a2) type_decl_gen2
+let add_type_decl3 name a1 a2 a3 = make_type_decl_no_op name (make_args3 a1 a2 a3) type_decl_gen3
+let add_type_decl4 name a1 a2 a3 a4 = make_type_decl_no_op name (make_args4 a1 a2 a3 a4) type_decl_gen4
 
 (* type extensions *)
 let type_ext_gen0 ~loc:_ ~path:_ _type_ext = []
@@ -31,7 +37,7 @@ let make_type_ext_no_op name args generator =
   add name ~str_type_ext |> ignore
 
 let add_type_ext name = make_type_ext_no_op name Args.empty type_ext_gen0
-let add_type_ext1 name args = make_type_ext_no_op name args type_ext_gen1
-let add_type_ext2 name args = make_type_ext_no_op name args type_ext_gen2
-let add_type_ext3 name args = make_type_ext_no_op name args type_ext_gen3
-let add_type_ext4 name args = make_type_ext_no_op name args type_ext_gen4
+let add_type_ext1 name a1 = make_type_ext_no_op name (make_args1 a1) type_ext_gen1
+let add_type_ext2 name a1 a2 = make_type_ext_no_op name (make_args2 a1 a2) type_ext_gen2
+let add_type_ext3 name a1 a2 a3 = make_type_ext_no_op name (make_args3 a1 a2 a3) type_ext_gen3
+let add_type_ext4 name a1 a2 a3 a4 = make_type_ext_no_op name (make_args4 a1 a2 a3 a4) type_ext_gen4

--- a/src/print_binable_functors.ml
+++ b/src/print_binable_functors.ml
@@ -96,9 +96,7 @@ let preprocess_impl str =
 
 let () =
   Ppxlib.Driver.register_transformation name ~preprocess_impl ;
-  let register_event_args =
-    let open Ppxlib.Deriving.Args in
-    empty +> arg "msg" __
-  in
-  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_args;
+  let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
+  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg;
+  Ppx_version.Dummy_derivers.add_type_ext "dhall_type";
   Ppxlib.Driver.standalone ()

--- a/src/print_versioned_types.ml
+++ b/src/print_versioned_types.ml
@@ -2,9 +2,7 @@
 
 let () =
   Ppx_version.Versioned_type.set_printing () ;
-  let register_event_args =
-    let open Ppxlib.Deriving.Args in
-    empty +> arg "msg" __
-  in
-  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_args;
+  let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
+  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg;
+  Ppx_version.Dummy_derivers.add_type_ext "dhall_type";
   Ppxlib.Driver.standalone ()


### PR DESCRIPTION
Add dummy deriver for `dhall_type`.

Also, build arguments in `Dummy_derivers`, instead of requiring its clients to do that.
