### PR TITLE
dhall_type is for type decls

### DIFF
--- a/src/print_binable_functors.ml
+++ b/src/print_binable_functors.ml
@@ -98,5 +98,5 @@ let () =
   Ppxlib.Driver.register_transformation name ~preprocess_impl ;
   let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
   Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg;
-  Ppx_version.Dummy_derivers.add_type_ext "dhall_type";
+  Ppx_version.Dummy_derivers.add_type_decl "dhall_type";
   Ppxlib.Driver.standalone ()

--- a/src/print_versioned_types.ml
+++ b/src/print_versioned_types.ml
@@ -4,5 +4,5 @@ let () =
   Ppx_version.Versioned_type.set_printing () ;
   let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
   Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg;
-  Ppx_version.Dummy_derivers.add_type_ext "dhall_type";
+  Ppx_version.Dummy_derivers.add_type_decl "dhall_type";
   Ppxlib.Driver.standalone ()


### PR DESCRIPTION
The dummy deriver is for type declarations, not type extensions. Oops.