### PR TITLE
add hlist dummy; registration funs

### DIFF
--- a/src/print_binable_functors.ml
+++ b/src/print_binable_functors.ml
@@ -94,9 +94,16 @@ let preprocess_impl str =
   ignore (traverse_ast#structure str {module_path= []}) ;
   str
 
-let () =
-  Ppxlib.Driver.register_transformation name ~preprocess_impl ;
+let register_dummy_type_ext_derivers () =
   let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
-  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg;
-  Ppx_version.Dummy_derivers.add_type_decl "dhall_type";
+  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg
+
+let register_dummy_type_decl_derivers () =
+  let derivers = ["dhall_type";"hlist"] in
+  List.iter derivers ~f:Ppx_version.Dummy_derivers.add_type_decl
+
+let () =
+  register_dummy_type_decl_derivers () ;
+  register_dummy_type_ext_derivers () ;
+  Ppxlib.Driver.register_transformation name ~preprocess_impl ;
   Ppxlib.Driver.standalone ()

--- a/src/print_versioned_types.ml
+++ b/src/print_versioned_types.ml
@@ -1,8 +1,17 @@
 (* print_versioned_types.ml *)
 
-let () =
-  Ppx_version.Versioned_type.set_printing () ;
+open Core_kernel
+
+let register_dummy_type_ext_derivers () =
   let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
-  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg;
-  Ppx_version.Dummy_derivers.add_type_decl "dhall_type";
+  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg
+
+let register_dummy_type_decl_derivers () =
+  let derivers = ["dhall_type";"hlist"] in
+  List.iter derivers ~f:Ppx_version.Dummy_derivers.add_type_decl
+
+let () =
+  register_dummy_type_decl_derivers () ;
+  register_dummy_type_ext_derivers () ;
+  Ppx_version.Versioned_type.set_printing () ;
   Ppxlib.Driver.standalone ()


### PR DESCRIPTION
Add dummy derivers for `hlist`. In printing programs, move registration of dummies to functions.