### PR TITLE
Less syntax-matching for attributes

### DIFF
--- a/src/versioned_module.ml
+++ b/src/versioned_module.ml
@@ -5,8 +5,6 @@ open Versioned_util
 (* option to `deriving version' *)
 type version_option = No_version_option | Asserted | Binable
 
-let parse_opt = Ast_pattern.parse ~on_error:(fun () -> None)
-
 (* TODO: Check if we need to optcomp this for 4.08 support. *)
 (*
 let create_attr ~loc attr_name attr_payload =
@@ -65,11 +63,7 @@ let rec add_deriving ~loc ~version_option attributes =
           in
           let has_version =
             List.exists args ~f:(fun arg ->
-                match parse_opt special_version loc arg (fun _ -> Some ()) with
-                | None ->
-                    false
-                | Some () ->
-                    true )
+                Option.is_some @@ parse_opt special_version loc arg (fun _ -> Some ()))
           in
           let needs_bin_io =
             match version_option with

--- a/src/versioned_util.ml
+++ b/src/versioned_util.ml
@@ -3,6 +3,8 @@
 open Core_kernel
 open Ppxlib
 
+let parse_opt = Ast_pattern.parse ~on_error:(fun () -> None)
+
 let mk_loc ~loc txt = {Location.loc; txt}
 
 let map_loc ~f {Location.loc; txt} = {Location.loc; txt= f txt}


### PR DESCRIPTION
Use `Ast_pattern` parsing for finding attributes and items in them, instead of grotesque pattern-matching on syntax.

This approach should help avoid problems with AST changes.

Closes https://github.com/CodaProtocol/coda/issues/5334.