### PR TITLE
Dummy derivers for to_enum, to_representatives

### DIFF
--- a/src/dummy_derivers.ml
+++ b/src/dummy_derivers.ml
@@ -41,3 +41,15 @@ let add_type_ext1 name a1 = make_type_ext_no_op name (make_args1 a1) type_ext_ge
 let add_type_ext2 name a1 a2 = make_type_ext_no_op name (make_args2 a1 a2) type_ext_gen2
 let add_type_ext3 name a1 a2 a3 = make_type_ext_no_op name (make_args3 a1 a2 a3) type_ext_gen3
 let add_type_ext4 name a1 a2 a3 a4 = make_type_ext_no_op name (make_args4 a1 a2 a3 a4) type_ext_gen4
+
+let register_dummies () =
+  let register_dummy_type_decl_derivers () =
+    let derivers = ["dhall_type";"hlist";"to_enum";"to_representatives"] in
+    Core_kernel.List.iter derivers ~f:add_type_decl
+  in
+  let register_dummy_type_ext_derivers () =
+    let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
+    add_type_ext1 "register_event" register_event_arg
+  in
+  register_dummy_type_decl_derivers ();
+  register_dummy_type_ext_derivers ()

--- a/src/print_binable_functors.ml
+++ b/src/print_binable_functors.ml
@@ -94,16 +94,7 @@ let preprocess_impl str =
   ignore (traverse_ast#structure str {module_path= []}) ;
   str
 
-let register_dummy_type_ext_derivers () =
-  let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
-  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg
-
-let register_dummy_type_decl_derivers () =
-  let derivers = ["dhall_type";"hlist"] in
-  List.iter derivers ~f:Ppx_version.Dummy_derivers.add_type_decl
-
 let () =
-  register_dummy_type_decl_derivers () ;
-  register_dummy_type_ext_derivers () ;
+  Ppx_version.Dummy_derivers.register_dummies () ;
   Ppxlib.Driver.register_transformation name ~preprocess_impl ;
   Ppxlib.Driver.standalone ()

--- a/src/print_versioned_types.ml
+++ b/src/print_versioned_types.ml
@@ -1,17 +1,6 @@
 (* print_versioned_types.ml *)
 
-open Core_kernel
-
-let register_dummy_type_ext_derivers () =
-  let register_event_arg = Ppxlib.Deriving.Args.(arg "msg" __) in
-  Ppx_version.Dummy_derivers.add_type_ext1 "register_event" register_event_arg
-
-let register_dummy_type_decl_derivers () =
-  let derivers = ["dhall_type";"hlist"] in
-  List.iter derivers ~f:Ppx_version.Dummy_derivers.add_type_decl
-
 let () =
-  register_dummy_type_decl_derivers () ;
-  register_dummy_type_ext_derivers () ;
+  Ppx_version.Dummy_derivers.register_dummies () ;
   Ppx_version.Versioned_type.set_printing () ;
   Ppxlib.Driver.standalone ()

--- a/src/versioned_type.ml
+++ b/src/versioned_type.ml
@@ -84,9 +84,8 @@ module Printing = struct
 
   (* singleton attribute *)
   let just_bin_io =
-    let loc = Location.none in
     let module E = Ppxlib.Ast_builder.Make (struct
-      let loc = loc
+      let loc = Location.none
     end) in
     let open E in
     ({txt="deriving";loc},PStr [%str bin_io])


### PR DESCRIPTION
Add dummy derivers for `to_enum`, `to_representatives`. 

Move registration of dummies from executable sources to library, so they're not duplicated.

In `print_binable_functors`, use `Ast_pattern` parsing instead of direct pattern-matching.