### PR TITLE
Less restrictive pattern for Binable

### DIFF
--- a/src/lint_version_syntax.ml
+++ b/src/lint_version_syntax.ml
@@ -309,7 +309,7 @@ let lint_ast =
                     , {pmod_desc= Pmod_ident {txt= arg; _}; _} )
               ; pmod_loc
               ; _ }
-            , {pmod_desc= Pmod_ident {txt= Lident _; _}; _} )
+            , _ )
           when List.mem
                  ["Of_binable"; "Of_binable1"; "Of_binable2"; "Of_binable3"]
                  of_binable ~equal:String.equal ->


### PR DESCRIPTION
The pattern-match for `Binable` functors was looking for a module identifier for the second argument. Of course, that argument could be any module expression.

I found this error when looking at `Sok_message` in Coda, which had an inline module for a call to `Binable.Of_binable`. The first argument should be a stable-versioned module, but wasn't, and the linter wasn't finding it. Making the change in this PR allowed the linter to find the error.
