### PR TITLE
Filter internal attributes for printing

### DIFF
--- a/src/versioned_type.ml
+++ b/src/versioned_type.ml
@@ -71,16 +71,26 @@ module Printing = struct
     let derivers =
       Ast_pattern.(attribute (string "deriving") (single_expr_payload __))
     in
-    match List.find_map attrs
-            ~f:(fun attr -> parse_opt derivers Location.none attr (fun l -> Some l)) with
+    match
+      List.find_map attrs ~f:(fun attr ->
+          parse_opt derivers Location.none attr (fun l -> Some l) )
+    with
     | Some derivers ->
-      let derivers =
-        match derivers.pexp_desc with Pexp_tuple derivers -> derivers | _ -> [derivers]
-      in
-      let bin_io_pattern = Ast_pattern.(pexp_ident (lident (string "bin_io"))) in
-      List.exists derivers ~f:(fun deriver ->
-          Option.is_some @@ parse_opt bin_io_pattern Location.none deriver (Some ()))
-    | None -> false
+        let derivers =
+          match derivers.pexp_desc with
+          | Pexp_tuple derivers ->
+              derivers
+          | _ ->
+              [derivers]
+        in
+        let bin_io_pattern =
+          Ast_pattern.(pexp_ident (lident (string "bin_io")))
+        in
+        List.exists derivers ~f:(fun deriver ->
+            Option.is_some
+            @@ parse_opt bin_io_pattern Location.none deriver (Some ()) )
+    | None ->
+        false
 
   (* singleton attribute *)
   let just_bin_io =
@@ -88,31 +98,35 @@ module Printing = struct
       let loc = Location.none
     end) in
     let open E in
-    ({txt="deriving";loc},PStr [%str bin_io])
+    ({txt= "deriving"; loc}, PStr [%str bin_io])
 
   (* remove internal attributes, on core type in manifest and in records or variants in kind *)
   let type_decl_remove_internal_attributes type_decl =
     let removed_in_kind =
       match type_decl.ptype_kind with
       | Ptype_variant ctors ->
-        Ptype_variant (List.map ctors ~f:(fun ctor ->
-            {ctor with pcd_attributes = []}))
+          Ptype_variant
+            (List.map ctors ~f:(fun ctor -> {ctor with pcd_attributes= []}))
       | Ptype_record labels ->
-        Ptype_record (List.map labels ~f:(fun label ->
-            {label with pld_attributes = []}))
-      | kind -> kind
+          Ptype_record
+            (List.map labels ~f:(fun label -> {label with pld_attributes= []}))
+      | kind ->
+          kind
     in
     let removed_in_manifest =
       Option.map type_decl.ptype_manifest ~f:(fun core_type ->
-          { core_type with ptyp_attributes = []})
+          {core_type with ptyp_attributes= []} )
     in
-    {type_decl with ptype_manifest = removed_in_manifest; ptype_kind = removed_in_kind }
+    { type_decl with
+      ptype_manifest= removed_in_manifest
+    ; ptype_kind= removed_in_kind }
 
   (* filter attributes from types, except for bin_io, don't care about changes to others *)
   let filter_type_decls_attrs type_decl =
     (* retain only `deriving bin_io` in deriving list *)
     let ptype_attributes =
-      if contains_deriving_bin_io type_decl.ptype_attributes then [just_bin_io] else []
+      if contains_deriving_bin_io type_decl.ptype_attributes then [just_bin_io]
+      else []
     in
     let type_decl_no_attrs = type_decl_remove_internal_attributes type_decl in
     {type_decl_no_attrs with ptype_attributes}


### PR DESCRIPTION
Remove internal attributes of type declarations when printing. Such attributes don't affect `Bin_prot` serialization, so adding or removing them won't invalidate versioned types. That way, the Mina CI linter will allow such changes, without having to create a new versioned type.

I looked at the `ppx_bin_prot` repo; there don't appear to be any attributes used with `deriving bin_io`.

I ran `print_versioned_types` on variant type, a record type, and a type constructor (int), and verified that attributes were not printed.