### PR TITLE
preparing repo for tagging / publishing

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,21 @@
+name: changes
+
+on: [pull_request, push]
+
+jobs:
+  run_changes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v2
+
+      - name: Set up ocaml
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: 4.12.0
+
+      - name: Compare opam and dune files
+        run: |
+          opam-dune-lint
+          

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,21 +1,40 @@
-name: changes
+name: check build
 
 on: [pull_request, push]
 
 jobs:
-  run_changes:
+  run_dune_build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR
         uses: actions/checkout@v2
 
-      - name: Set up ocaml
+      - name: Set up ocaml 4.07.1
         uses: avsm/setup-ocaml@v1
         with:
-          ocaml-version: 4.12.0
+          ocaml-version: 4.07.1
 
-      - name: Compare opam and dune files
+      - name: Make sure we can build
         run: |
-          opam-dune-lint
-          
+          opam install dune ppxlib ppx_bin_prot core_kernel
+          eval $(opam env)
+          dune build -p ppx_version
+
+  run_opam_pin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v2
+
+      - name: Set up ocaml 4.07.1
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: 4.07.1
+
+      - name: Make sure we can opam pin
+        run: |
+          opam pin add ppx_version .
+
+  

--- a/ppx_version.opam
+++ b/ppx_version.opam
@@ -1,5 +1,14 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+synopsis: ""
+description:
+  "OCaml extension point (ppx) meant to assure the stability of types and their Bin_prot serializations."
+maintainer: "opensource@o1labs.org"
+depends: [
+  "ocaml" {<= "4.07.1"}
+  "ppxlib"
+  "ppx_bin_prot"
+  "core_kernel" {< "v0.13"}
+  "dune" {>= "2.5"}
 ]
+build: ["dune" "build" "-p" name "-j" jobs]

--- a/src/versioned_util.ml
+++ b/src/versioned_util.ml
@@ -5,24 +5,27 @@ open Ppxlib
 
 let parse_opt = Ast_pattern.parse ~on_error:(fun () -> None)
 
-let mk_loc ~loc txt = {Location.loc; txt}
+let mk_loc ~loc txt = { Location.loc; txt }
 
-let map_loc ~f {Location.loc; txt} = {Location.loc; txt= f txt}
+let map_loc ~f { Location.loc; txt } = { Location.loc; txt = f txt }
 
-let check_modname ~loc name =
-  if name = "Stable" then name
-  else
-    Location.raise_errorf ~loc
-      "Expected a module named Stable, but got a module named %s." name
+let check_modname ~loc name : string =
+  match name with
+  | "Stable" -> name
+  | _ ->
+      Location.raise_errorf ~loc
+        "Expected a module named Stable, but got a module named %s." name
 
 (* for diffing types and binable functors, replace newlines in standard formatter
    with a space, so string is all on one line *)
 let diff_formatter =
   let out_funs = Format.(pp_get_formatter_out_functions std_formatter ()) in
   let out_funs' =
-    { out_funs with
-      out_newline= (fun () -> out_funs.out_spaces 1)
-    ; out_indent= (fun _ -> ()) }
+    {
+      out_funs with
+      out_newline = (fun () -> out_funs.out_spaces 1);
+      out_indent = (fun _ -> ());
+    }
   in
   Format.formatter_of_out_functions out_funs'
 
@@ -39,7 +42,7 @@ let validate_module_version module_version loc =
           Location.raise_errorf ~loc
             "Versioning module name must be Vn, for some positive number n, \
              got: \"%s\""
-            module_version ) ;
+            module_version);
     (* invariant: 0th char is digit *)
     if Int.equal (Char.get_digit_exn numeric_part.[0]) 0 then
       Location.raise_errorf ~loc
@@ -59,6 +62,7 @@ let version_of_versioned_module_name name =
 
        add to this list as needed; but more items slows things down
  *)
-let jane_street_library_modules = ["Uuid"]
+let jane_street_library_modules = [ "Uuid" ]
 
-let jane_street_modules = ["Core"; "Core_kernel"] @ jane_street_library_modules
+let jane_street_modules =
+  [ "Core"; "Core_kernel" ] @ jane_street_library_modules


### PR DESCRIPTION
Before publishing the package to our [opam repo](https://github.com/o1-labs/opam-repository/) here's a few changes:

* `package.opam` clean up, required for [opam-publish](https://github.com/ocaml-opam/opam-publish) to work
* `opam-dune-lint` in CI to maintain consistency between `dune` and `package.opam` files.