### PR TITLE
Use latest ppxlib AST

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -10,14 +10,14 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v2
 
-      - name: Set up ocaml 4.07.1
+      - name: Set up ocaml 4.11.2
         uses: avsm/setup-ocaml@v1
         with:
-          ocaml-version: 4.07.1
+          ocaml-version: 4.11.2
 
       - name: Make sure we can build
         run: |
-          opam install dune ppxlib ppx_bin_prot core_kernel
+          opam install dune ppxlib.0.25.0 ppx_bin_prot core_kernel.v0.14.1
           eval $(opam env)
           dune build -p ppx_version
 
@@ -28,10 +28,10 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v2
 
-      - name: Set up ocaml 4.07.1
+      - name: Set up ocaml 4.11.2
         uses: avsm/setup-ocaml@v1
         with:
-          ocaml-version: 4.07.1
+          ocaml-version: 4.11.2
 
       - name: Make sure we can opam pin
         run: |

--- a/ppx_version.opam
+++ b/ppx_version.opam
@@ -12,10 +12,10 @@ See the readme at https://github.com/o1-labs/ppx_version/README.md for more info
 dev-repo: "git+https://github.com/o1-labs/ppx_version.git"
 maintainer: "opensource@o1labs.org"
 depends: [
-  "ocaml" {<= "4.07.1"}
-  "ppxlib"
+  "ocaml" {= "4.11.2"}
+  "ppxlib" {>= "0.25.0"}
   "ppx_bin_prot"
-  "core_kernel" {< "v0.13"}
+  "core_kernel" {< "v0.15"}
   "dune" {>= "2.5"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/src/bin_io_unversioned.ml
+++ b/src/bin_io_unversioned.ml
@@ -87,10 +87,8 @@ let validate_type_decl inner2_modules type_decl =
       ()
 
 let ctxt_base =
-  let omp_config =
-    Migrate_parsetree.Driver.make_config ~tool_name:"ppxlib_driver" ()
-  in
-  Expansion_context.Base.top_level ~omp_config ~file_path:""
+  Expansion_context.Base.top_level ~tool_name:"ppxlib_driver" ~file_path:""
+    ~input_name:""
 
 let rewrite_to_bin_io ~loc ~path (_rec_flag, type_decls) =
   let type_decl1 = List.hd_exn type_decls in

--- a/src/lint_version_syntax.ml
+++ b/src/lint_version_syntax.ml
@@ -297,7 +297,7 @@ let lint_ast =
       let acc' =
         match expr.pmod_desc with
         (* don't match special case of functor with () argument *)
-        | Pmod_functor (_label, Some _mty, body) ->
+        | Pmod_functor (Named _, body) ->
             self#module_expr body {acc with in_functor= true}
         | Pmod_apply
             ( { pmod_desc=
@@ -427,10 +427,10 @@ let lint_ast =
 
     method! structure_item str acc =
       match str.pstr_desc with
-      | Pstr_module {pmb_name; pmb_expr; _} ->
+      | Pstr_module {pmb_name = {txt = Some name; _}; pmb_expr; _} ->
           let acc' =
             self#module_expr pmb_expr
-              {acc with module_path= pmb_name.txt :: acc.module_path}
+              {acc with module_path= name :: acc.module_path}
           in
           acc_with_errors acc acc'.errors
       | Pstr_type (rec_flag, type_decls) ->

--- a/src/versioned_util.ml
+++ b/src/versioned_util.ml
@@ -9,6 +9,8 @@ let mk_loc ~loc txt = { Location.loc; txt }
 
 let map_loc ~f { Location.loc; txt } = { Location.loc; txt = f txt }
 
+let some_loc (x : 'a loc) = map_loc ~f:Option.some x
+
 let check_modname ~loc name : string =
   if String.equal name "Stable" then name
   else

--- a/test/versioned_module_good.ml
+++ b/test/versioned_module_good.ml
@@ -157,7 +157,7 @@ module M5 = struct
         let of_binable = Fn.id
       end
 
-      include Binable.Of_binable (Core_kernel.Bool.Stable.V1) (Arg)
+      include Binable.Of_binable_without_uuid (Core_kernel.Bool.Stable.V1) (Arg)
     end
   end]
 end

--- a/tools/print_binable_functors.ml
+++ b/tools/print_binable_functors.ml
@@ -79,10 +79,10 @@ let traverse_ast =
 
     method! structure_item stri acc =
       match stri.pstr_desc with
-      | Pstr_module {pmb_name; pmb_expr; _} ->
+      | Pstr_module {pmb_name = {txt = Some name; _}; pmb_expr; _} ->
           ignore
             (self#module_expr pmb_expr
-               {module_path= pmb_name.txt :: acc.module_path}) ;
+               {module_path= name :: acc.module_path}) ;
           acc
       | Pstr_extension ((name, _payload), _attrs)
         when List.mem


### PR DESCRIPTION
Some small modifications to be compatible with `ppxlib.0.25.0` (for https://github.com/MinaProtocol/mina/pull/11114)

PR for the currently used `feature/binable-functors-js-14` branch on Mina. Eventually this branch should be merged to `master`, or this PR can be redirected to `master` now.